### PR TITLE
Update setup-hotspot.sh

### DIFF
--- a/setup-hotspot.sh
+++ b/setup-hotspot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$(hrpi-version)" = "rpi-3" ]; then
+if [ "$(hrpi_version)" = "rpi-3" ]; then
     cd /tmp || exit
     wget -O rpi3-hotspot.zip "https://gitlab.inria.fr/dcaselli/rpi3-hotspot/repository/archive.zip?ref=3.0.1"
     unzip rpi3-hotspot.zip


### PR DESCRIPTION
Variable name "hrpi-version" is incorrect and gives a shell error.
Replace "hrpi-version"  by  "hrpi_version".

By the way I wonder where this varaible is set in the installation process ?